### PR TITLE
Support custom tags when parsing and stringifying playlists

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,4 +1,4 @@
-import { Key } from './types';
+import { CustomTags, Key, MasterPlaylist, MediaPlaylist } from './types';
 import * as utils from './utils';
 
 const ALLOW_REDUNDANCY = [
@@ -428,7 +428,12 @@ function buildParts(lines, parts) {
     return hint;
 }
 
-export function stringify(playlist) {
+function buildCustomTags(lines: string[], customTags: CustomTags) {
+    const pairs = Object.entries(customTags).map(([k, v]) => `${k}=${v}`);
+    lines.push(`#EXT-X-CUSTOM-TAGS:${pairs.join(';')}`);
+}
+
+export function stringify(playlist: MasterPlaylist | MediaPlaylist) {
     utils.PARAMCHECK(playlist);
     utils.ASSERT('Not a playlist', playlist.type === 'playlist');
     const lines = new LineArray(playlist.uri);
@@ -445,6 +450,9 @@ export function stringify(playlist) {
                 playlist.start.precise ? ',PRECISE=YES' : ''
             }`,
         );
+    }
+    if (playlist.customTags) {
+        buildCustomTags(lines, playlist.customTags);
     }
     if (playlist.isMasterPlaylist) {
         buildMasterPlaylist(lines, playlist);

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,6 +417,8 @@ export interface PlaylistStart {
     precise: boolean;
 }
 
+export type CustomTags = Record<string, string | boolean | number>;
+
 export interface PlaylistProperties extends Data {
     isMasterPlaylist: boolean;
     uri: string;
@@ -424,10 +426,11 @@ export interface PlaylistProperties extends Data {
     independentSegments: boolean;
     start: PlaylistStart;
     source: string;
+    customTags: CustomTags;
 }
 
 export type PlaylistOptionalConstructorProperties = Partial<
-    Pick<PlaylistProperties, 'uri' | 'version' | 'independentSegments' | 'start' | 'source'>
+    Pick<PlaylistProperties, 'uri' | 'version' | 'independentSegments' | 'start' | 'source' | 'customTags'>
 >;
 export type PlaylistRequiredConstructorProperties = Pick<PlaylistProperties, 'isMasterPlaylist'>;
 export type PlaylistConstructorProperties = PlaylistOptionalConstructorProperties &
@@ -440,6 +443,7 @@ export class Playlist extends Data implements PlaylistProperties {
     public independentSegments: boolean;
     public start: PlaylistStart;
     public source: string;
+    public customTags: CustomTags;
 
     constructor({
         isMasterPlaylist, // required
@@ -448,6 +452,7 @@ export class Playlist extends Data implements PlaylistProperties {
         independentSegments = false,
         start,
         source,
+        customTags = {},
     }: PlaylistConstructorProperties) {
         super('playlist');
         utils.PARAMCHECK(isMasterPlaylist);
@@ -457,6 +462,7 @@ export class Playlist extends Data implements PlaylistProperties {
         this.independentSegments = independentSegments;
         this.start = start;
         this.source = source;
+        this.customTags = customTags;
     }
 }
 


### PR DESCRIPTION
* Add new property to playlist, customTags, that contains a record with
      a string key and a value that is either string, number, or boolean.
* Example: `#EXT-X-CUSTOM-TAGS:foo=bar;fizz=true;boop=1`

LIVE-3972